### PR TITLE
change to name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,7 @@ export const getTrackEventArgs = (
   const timeStamp = getTimestamp(event.client)
 
   const requestBody = {
-    event: event.type === 'pageview' ? '$pageview' : event.type,
+    event: event.type === 'pageview' ? '$pageview' : event.name,
     timestamp: timeStamp,
     distinct_id: distinctID,
     properties: {


### PR DESCRIPTION
First of all, thanks for taking time to create this managed component! Very valuable work.

**Current behaviour**
Currently, when you track an event, the name that shows up in the posthog dashboard will always be "event" which doesn't make sense.

<img width="1231" alt="image" src="https://github.com/mountainash/posthog-managed-component/assets/12101091/86e8ef65-4923-4402-a8fd-a6d20b23175e">

**Expected behaviour**
Instead of the type that is now used as the event name, the actual event name should be used as described in the docs: https://posthog.com/tutorials/api-capture-events

Then you'll also be able to see the correct event name in the ph dashboard:
<img width="1213" alt="image" src="https://github.com/mountainash/posthog-managed-component/assets/12101091/ad57115f-1fcd-4422-b005-9f8378f95111">

**Shortcomings of this PR**

1 test case currently fails but it's too complex for me right now to dig into.